### PR TITLE
Roz departures API bugfix

### DIFF
--- a/client/src/components/DepartureInfo/DepartureInfo.css
+++ b/client/src/components/DepartureInfo/DepartureInfo.css
@@ -7,6 +7,10 @@
     @apply max-h-96 w-full;
 }
 
+.no-departures, .loading {
+    @apply text-center;
+}
+
 .transport-grid {
     @apply flex justify-start w-full flex-col;
 }
@@ -29,7 +33,7 @@
 }
 
 .transport-listing {
-    @apply border-b-2 border-blue-200 m-2;
+    @apply border-b-2 border-blue-200 my-2;
 }
 
 .transport-listing__info {

--- a/client/src/components/DepartureInfo/DepartureInfo.css
+++ b/client/src/components/DepartureInfo/DepartureInfo.css
@@ -19,13 +19,17 @@
     @apply font-bold text-center py-2 w-1/4 flex-shrink-0;
 }
 
+.transport-grid__origin-station {
+    @apply text-center pb-2;
+}
+
 .transport-grid-body {
     @apply 
     w-full h-72 overflow-y-scroll;
 }
 
 .transport-listing {
-    @apply border-b-2 border-blue-200 mx-2;
+    @apply border-b-2 border-blue-200 m-2;
 }
 
 .transport-listing__info {

--- a/client/src/components/DepartureInfo/DepartureInfo.tsx
+++ b/client/src/components/DepartureInfo/DepartureInfo.tsx
@@ -21,14 +21,14 @@ const DepartureInfo: React.FC = () => {
           setError(null);
           try {
               const response = await fetch(
-                  `http://localhost:3000/api/station-location?latitude=${stateCoordinates.latitude}&longitude=${stateCoordinates.longitude}`
+                  `http://localhost:3000/api/departure-info?latitude=${stateCoordinates.latitude}&longitude=${stateCoordinates.longitude}`
               );
               if (!response.ok) {
                   throw new Error("Fel vid hämtning av data");
               }
-              const departures = await response.json();
-              if (departures) {
-                  const departureItems = departures.map(({ 
+              const departureData = await response.json();
+              if (departureData) {
+                  const departureItems = departureData.map(({ 
                       Product, 
                       name, 
                       direction, 

--- a/client/src/components/DepartureInfo/DepartureInfo.tsx
+++ b/client/src/components/DepartureInfo/DepartureInfo.tsx
@@ -28,25 +28,26 @@ const DepartureInfo: React.FC = () => {
               }
               const departureData = await response.json();
               if (departureData) {
-                  const departureItems = departureData.map(({ 
-                      Product, 
-                      name, 
-                      direction, 
-                      time, 
-                      Notes, 
-                      rtTrack }: IncomingApiData): TransportItem => ({
-                      TransportOperator: Product[0].operator,
-                      TransportItem: name,
-                      Direction: direction,
-                      DepartureTime: time.slice(0,5),
-                      TrainNotes: (Notes?.Note
-                          .map(({ value }) => (value)) 
-                          .filter(value => !["EU förordning", "Lag", "tillämpas"].some(word => value.includes(word)))),
-                      TrainTrack: rtTrack 
-                  }));
-                  setTransportData(departureItems);
-                  console.log(departures)
-                  console.log(departureItems)
+                const departureItems = departureData.map(({
+                    Product, 
+                    name, 
+                    direction, 
+                    time,
+                    stop, 
+                    Notes, 
+                    rtTrack }: IncomingApiData): TransportItem => ({
+                    StationName: stop,
+                    TransportOperator: Product[0].operator,
+                    TransportItem: name,
+                    Direction: direction,
+                    DepartureTime: time.slice(0,5),
+                    TrainNotes: (Notes?.Note
+                        .map(({ value }) => (value)) 
+                        .filter(value => !["EU förordning", "Lag", "tillämpas"].some(word => value.includes(word)))),
+                    TrainTrack: rtTrack 
+                }));
+                setTransportData(departureItems);
+                console.log(departureItems)
               } else {
                   setError("No station found in your area."); 
                   return null;
@@ -75,6 +76,7 @@ const DepartureInfo: React.FC = () => {
 
             {transportData.length > 0 && (
             <div className="transport-grid">
+                <div className="transport-grid__origin-station">från {transportData[0].StationName}</div>
                     <div className="transport-header">
                         <div className="transport-header__heading">Operatör</div>
                         <div className="transport-header__heading">Transporttyp</div>

--- a/client/src/components/DepartureInfo/DepartureInfo.tsx
+++ b/client/src/components/DepartureInfo/DepartureInfo.tsx
@@ -11,85 +11,60 @@ const DepartureInfo: React.FC = () => {
   const stateCoordinates = useStore<Coordinates>((state) => state.coordinates);
   const [transportData, setTransportData] = useState<TransportItem[]>([]);
   
-  
-    const fetchNearestStation = async () => {
-        if(!stateCoordinates) {
-            setError("No Coordinates");
-            return null;
-        }
-        setLoading(true);
-        setError(null);
-        try {
-            const response = await fetch(
-                `http://localhost:3000/api/station-location?latitude=${stateCoordinates.latitude}&longitude=${stateCoordinates.longitude}`
-            );
-            if (!response.ok) {
-                throw new Error("Fel vid hämtning av data");
-            }
-            const station = await response.json();
-            if (station) {
-                return station;
-            } else {
-                setError("No station found in your area."); 
-                return null;
-            }
-        } catch (err) {
-            console.error("Error fetching nearest station:", err);
-            setError("Failed to fetch station data."); 
-        }};
-
-    const fetchDepartureData = async () => {
-        let station = await fetchNearestStation();
-        try {
-            const response = await fetch(`http://localhost:3000/api/departure-info?stationId=${station}`);
-            if (!response.ok) {
-                throw new Error("Fel vid hämtning av data");
-            }
-            const incomingDepartures = await response.json();
-            const departureItems = incomingDepartures.map(({ 
-                Product, 
-                name, 
-                direction, 
-                time, 
-                Notes, 
-                rtTrack }: IncomingApiData): TransportItem => ({
-                TransportOperator: Product[0].operator,
-                TransportItem: name,
-                Direction: direction,
-                DepartureTime: time.slice(0,5),
-                TrainNotes: (Notes?.Note
-                    .map(({ value }) => (value)) 
-                    .filter(value => !["EU förordning", "Lag", "tillämpas"].some(word => value.includes(word)))),
-                TrainTrack: rtTrack 
-            }));
-            setTransportData(departureItems);
-            console.log(incomingDepartures)
-            console.log(departureItems)
-        } catch (err) {
-            console.error("Error fetching transport data:", err);
-            setError("Failed to fetch transport data.");
-        }};
-
   useEffect(() => {
-    if (!stateCoordinates) return;
-
-        const fetchAllDepartureInfo = async () => {
-            try {
-                setLoading(true);
-                await fetchDepartureData();
-            } catch (error) {
-                console.error("Error", error)
-            } finally {
-                setLoading(false);
-            }
-        };
-
-        fetchAllDepartureInfo();
-    }, [stateCoordinates]);
+      const fetchDepartureData = async () => {
+          if(!stateCoordinates) {
+              setError("No Coordinates");
+              return null;
+          }
+          setLoading(true);
+          setError(null);
+          try {
+              const response = await fetch(
+                  `http://localhost:3000/api/station-location?latitude=${stateCoordinates.latitude}&longitude=${stateCoordinates.longitude}`
+              );
+              if (!response.ok) {
+                  throw new Error("Fel vid hämtning av data");
+              }
+              const departures = await response.json();
+              if (departures) {
+                  const departureItems = departures.map(({ 
+                      Product, 
+                      name, 
+                      direction, 
+                      time, 
+                      Notes, 
+                      rtTrack }: IncomingApiData): TransportItem => ({
+                      TransportOperator: Product[0].operator,
+                      TransportItem: name,
+                      Direction: direction,
+                      DepartureTime: time.slice(0,5),
+                      TrainNotes: (Notes?.Note
+                          .map(({ value }) => (value)) 
+                          .filter(value => !["EU förordning", "Lag", "tillämpas"].some(word => value.includes(word)))),
+                      TrainTrack: rtTrack 
+                  }));
+                  setTransportData(departureItems);
+                  console.log(departures)
+                  console.log(departureItems)
+              } else {
+                  setError("No station found in your area."); 
+                  return null;
+              }
+          } catch (err) {
+              console.error("Error fetching nearest station:", err);
+              setError("Failed to fetch station data."); 
+              setLoading(false);
+          }}
+          
+          if (stateCoordinates) {
+            fetchDepartureData();
+          };
+  }, [stateCoordinates]);
 
     if (loading) {
     <div className="departure-content">
-        <h3>Transport Departures</h3>
+        <h3>Transport avgår</h3>
         {error ? error : "Läddar data..."}
     </div>
     }

--- a/client/src/types/departureinfo.ts
+++ b/client/src/types/departureinfo.ts
@@ -1,3 +1,7 @@
+export interface NoDepartures {
+  NoDepartures: string;
+}
+
 export type IncomingApiData = {
   StationName: string;
   Product: {operator: string}[];
@@ -9,7 +13,7 @@ export type IncomingApiData = {
   rtTrack: string;
 }
 
-export type TransportItem = {
+export interface TransportItem {
     StationName: string;
     TransportOperator: string;  
     TransportItem: string; // Name plus number, i.e, "Länstrafik - Buss 430"

--- a/client/src/types/departureinfo.ts
+++ b/client/src/types/departureinfo.ts
@@ -1,13 +1,16 @@
 export type IncomingApiData = {
+  StationName: string;
   Product: {operator: string}[];
   name: string;
   direction: string;
   time: string;
+  stop: string;
   Notes:  {Note: string[]};
   rtTrack: string;
 }
 
 export type TransportItem = {
+    StationName: string;
     TransportOperator: string;  
     TransportItem: string; // Name plus number, i.e, "Länstrafik - Buss 430"
     Direction: string; // Destination

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -131,9 +131,7 @@ app.get("/api/departure-info", async (req: express.Request, res: express.Respons
 
             let departures: any = null;
             let triedIndexes: number[] = [];
-            let goodStationName: string = "";
             
-            console.log("STATIONS", stationsArray);
             //If the API call returns an object with no "Departure" object, try the next object's station ID in the stationsArray.
             
             for (let index = 0; index < stationsArray.length; index++) {
@@ -148,14 +146,16 @@ app.get("/api/departure-info", async (req: express.Request, res: express.Respons
                 }
                 const departuresData: any = await departuresResponse.json();
                 if (departuresData.Departure && departuresData.Departure.length > 0) {
+                    console.log("STATION NAME", station.stationName)
                     departures = departuresData.Departure;
-                    departures.StationName = station.stationName;
                     break;
                 }
                 triedIndexes.push(index);
+
+                //todo: add logic if there are actually no departures for any station nearby.
             }
                 if (departures) {
-                        console.log(departures);
+                    console.log(departures)
                     res.json(departures)
                 }
                 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -25,7 +25,7 @@ app.get("/api/location", async (req: express.Request, res: express.Response): Pr
         if (!apiKey) {
             throw new Error("Missing Google Maps API key.");
         }
-        const response = await fetch(`https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(address)}&key=${apiKey}`);
+        const response = await fetch(`https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(address)}&region=sv&key=${apiKey}`);
 
         if (!response.ok) {
           throw new Error(`HTTP error! Status: ${response.status}`);
@@ -154,7 +154,6 @@ app.get("/api/departure-info", async (req: express.Request, res: express.Respons
         }
             
         if (departures) {
-            console.log(departures)
             res.json(departures)
         } else {
             console.log("Couldn't find nothin'")

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -11,3 +11,24 @@ export interface GoogleMapsData
         } 
     }[]; 
 };
+
+export interface rawStopLocation {
+    StopLocation: {
+        productAtStop: string[],
+        timezoneOffset: number,
+        id: string,
+        extId: string,
+        name: string,
+        lon: number,
+        lat: number,
+        weight: number,
+        dist: number,
+        products: number,
+        minimumChangeDuration: string
+    }
+}
+
+export type cleanStopLocation = {
+    stationId: string,
+    stationName: string,
+}


### PR DESCRIPTION
There was a bug where for the departures component, I was grabbing the first station ID number returned and feeding that as a parameter to the second API call for the departure data. If that first ID number returned an object with no Departures object, this would produce a JSON error and a blank departures component.

I added a for loop to go through the array of station IDs until it returned a result with a departures object, then use the first successfully returned item with a Departure object as the data for the departures board. For better context in the UI, I added the stop information so the user knows where exactly the departures are leaving from. I also added a message in case all station IDs are looped through and no departures are found, and fixed the loading logic in the departures component.